### PR TITLE
Fix latex formatting in lecture03.ipynb for vscode users

### DIFF
--- a/lecture/03/lecture03.ipynb
+++ b/lecture/03/lecture03.ipynb
@@ -186,7 +186,7 @@
     "\n",
     "For a Poisson process, the probability of receiving a number of counts $k$ is given by the **Poisson distribution:**\n",
     "\n",
-    "$$P(k;\\lambda) = \\frac{lambda^k e^{-\\lambda}}{k!}$$\n",
+    "$$P(k;\\lambda) = \\frac{\lambda^k e^{-\\lambda}}{k!}$$\n",
     "\n",
     "Both the mean and the variance of this distribution are equal to $\\lambda$. By extension, the standard deviation is $\\sqrt{\\lambda}$.\n",
     "\n",

--- a/lecture/03/lecture03.ipynb
+++ b/lecture/03/lecture03.ipynb
@@ -186,7 +186,7 @@
     "\n",
     "For a Poisson process, the probability of receiving a number of counts $k$ is given by the **Poisson distribution:**\n",
     "\n",
-    "$$P(k;\\lambda) = \\frac{\lambda^k e^{-\\lambda}}{k!}$$\n",
+    "$$P(k;\\lambda) = \\frac{\\lambda^k e^{-\\lambda}}{k!}$$\n",
     "\n",
     "Both the mean and the variance of this distribution are equal to $\\lambda$. By extension, the standard deviation is $\\sqrt{\\lambda}$.\n",
     "\n",

--- a/lecture/03/lecture03.ipynb
+++ b/lecture/03/lecture03.ipynb
@@ -393,7 +393,7 @@
    "source": [
     "If your sample is indeed drawn from a random distribution:\n",
     "\n",
-    "### <center> $ \\left| x - \\mu \\right| > 3\\sigma$ implies $X$ is more extreme than the distribution 0.27% of the time </center>"
+    "### <center> $$\\left| x - \\mu \\right| > 3\\sigma$$ implies $X$ is more extreme than the distribution 0.27% of the time </center>"
    ]
   },
   {

--- a/lecture/03/lecture03.ipynb
+++ b/lecture/03/lecture03.ipynb
@@ -116,7 +116,7 @@
     "### The Method of Moments (Chebyshev, 1887)\n",
     "We know how to estimate moments if we have an underlying description of the population - the PDF\n",
     "\n",
-    "### <center> $\\mu_{n} = \\int_{-\\infty}^{\\infty} (x-c)^{n} \\cdot p(x) \\cdot dx $ </center>"
+    "### <center> $$\\mu_{n} = \\int_{-\\infty}^{\\infty} (x-c)^{n} \\cdot p(x) \\cdot dx $$</center>"
    ]
   },
   {


### PR DESCRIPTION
before:
<img width="921" alt="Screenshot 2025-01-29 at 8 50 13 AM" src="https://github.com/user-attachments/assets/1994388f-c5aa-428d-b200-4359f22fbd9c" />

after:
<img width="920" alt="Screenshot 2025-01-29 at 8 50 22 AM" src="https://github.com/user-attachments/assets/ed4bd961-7b66-48c5-ad81-e9cffe4197c6" />
